### PR TITLE
Removing extraneous requires and dependencies from clouseau.

### DIFF
--- a/lib/clouseau.js
+++ b/lib/clouseau.js
@@ -1,6 +1,3 @@
-var logger = require('spruce').init();
-var fs = require('fs');
-
 var Profiler = {
     tree: {
         name: "main",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
 	],
 	"version": "0.1.4",
 	"main": "./lib/clouseau",
-	"dependencies": {
-		"spruce": "1.0.2"
-	},
 	"devDependencies": {
 		"docco": "*"
 	},


### PR DESCRIPTION
cc @exojason 

Was going to switch from spruce to winston, then noticed that the logger wasn't being used in the source code at all.
